### PR TITLE
Farsight nerf / Blazing fix

### DIFF
--- a/core/src/main/assets/messages/actors/actors.properties
+++ b/core/src/main/assets/messages/actors/actors.properties
@@ -1122,7 +1122,7 @@ actors.hero.talent.seer_shot.desc=_+1:_ When the Huntress fires an arrow at the 
 actors.hero.talent.seer_shot.meta_desc=_If this talent is gained by a different hero_ it will trigger from any thrown weapon.
 
 actors.hero.talent.farsight.title=farsight
-actors.hero.talent.farsight.desc=_+1:_ The Sniper's vision range is _increased by 15%_.\n\n_+2:_ The Sniper's vision range is _increased by 30%_.\n\n_+3:_ The Sniper's vision range is _increased by 45%_.
+actors.hero.talent.farsight.desc=_+1:_ The Sniper's vision range is _increased by 18%_.\n\n_+2:_ The Sniper's vision range is _increased by 36%_.\n\n_+3:_ The Sniper's vision range is _increased by 55%_.
 actors.hero.talent.shared_enchantment.title=shared enchantment
 actors.hero.talent.shared_enchantment.desc=_+1:_ Thrown weapons have a _33% chance_ to use the enchantment on the Sniper's bow.\n\n_+2:_ Thrown weapons have a _67% chance_ to use the enchantment on the Sniper's bow.\n\n_+3:_ Thrown weapons have a _100% chance_ to use the enchantment on the Sniper's bow.\n\nThis talent does not apply to darts shot from an enchanted crossbow, they already trigger the crossbow's enchantment.
 actors.hero.talent.shared_upgrades.title=shared upgrades

--- a/core/src/main/assets/messages/actors/actors.properties
+++ b/core/src/main/assets/messages/actors/actors.properties
@@ -1122,7 +1122,7 @@ actors.hero.talent.seer_shot.desc=_+1:_ When the Huntress fires an arrow at the 
 actors.hero.talent.seer_shot.meta_desc=_If this talent is gained by a different hero_ it will trigger from any thrown weapon.
 
 actors.hero.talent.farsight.title=farsight
-actors.hero.talent.farsight.desc=_+1:_ The Sniper's vision range is _increased by 25%_.\n\n_+2:_ The Sniper's vision range is _increased by 50%_.\n\n_+3:_ The Sniper's vision range is _increased by 75%_.
+actors.hero.talent.farsight.desc=_+1:_ The Sniper's vision range is _increased by 15%_.\n\n_+2:_ The Sniper's vision range is _increased by 30%_.\n\n_+3:_ The Sniper's vision range is _increased by 45%_.
 actors.hero.talent.shared_enchantment.title=shared enchantment
 actors.hero.talent.shared_enchantment.desc=_+1:_ Thrown weapons have a _33% chance_ to use the enchantment on the Sniper's bow.\n\n_+2:_ Thrown weapons have a _67% chance_ to use the enchantment on the Sniper's bow.\n\n_+3:_ Thrown weapons have a _100% chance_ to use the enchantment on the Sniper's bow.\n\nThis talent does not apply to darts shot from an enchanted crossbow, they already trigger the crossbow's enchantment.
 actors.hero.talent.shared_upgrades.title=shared upgrades

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Dungeon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Dungeon.java
@@ -910,7 +910,7 @@ public class Dungeon {
 	//default to recomputing based on max hero vision, in case vision just shrank/grew
 	public static void observe(){
 		int dist = Math.max(Dungeon.hero.viewDistance, 8);
-		dist *= 1f + 0.25f*Dungeon.hero.pointsInTalent(Talent.FARSIGHT);
+		dist *= 1f + 0.18f*Dungeon.hero.pointsInTalent(Talent.FARSIGHT);
 
 		if (Dungeon.hero.buff(MagicalSight.class) != null){
 			dist = Math.max( dist, MagicalSight.DISTANCE );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/enchantments/Blazing.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/enchantments/Blazing.java
@@ -43,6 +43,8 @@ public class Blazing extends Weapon.Enchantment {
 		// lvl 1 - 50%
 		// lvl 2 - 60%
 		float procChance = (level+1f)/(level+3f) * Polished_procChanceMultiplier(attacker, weapon);
+		if(Dungeon.level.water[defender.pos]) procChance = 0;
+
 		if (Random.Float() < procChance) {
 
 			float powerMulti = Math.max(1f, procChance);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/enchantments/Blazing.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/enchantments/Blazing.java
@@ -43,7 +43,7 @@ public class Blazing extends Weapon.Enchantment {
 		// lvl 1 - 50%
 		// lvl 2 - 60%
 		float procChance = (level+1f)/(level+3f) * Polished_procChanceMultiplier(attacker, weapon);
-		if(Dungeon.level.water[defender.pos]) procChance = 0;
+		//if(Dungeon.level.water[defender.pos]) procChance = 0;
 
 		if (Random.Float() < procChance) {
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
@@ -1317,7 +1317,7 @@ public abstract class Level implements Bundlable {
 
 			float viewDist = c.viewDistance;
 			if (c instanceof Hero){
-				viewDist *= 1f + 0.15f*((Hero) c).pointsInTalent(Talent.FARSIGHT);
+				viewDist *= 1f + 0.18f*((Hero) c).pointsInTalent(Talent.FARSIGHT);
 				viewDist *= EyeOfNewt.visionRangeMultiplier();
 			}
 			

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
@@ -1317,7 +1317,7 @@ public abstract class Level implements Bundlable {
 
 			float viewDist = c.viewDistance;
 			if (c instanceof Hero){
-				viewDist *= 1f + 0.25f*((Hero) c).pointsInTalent(Talent.FARSIGHT);
+				viewDist *= 1f + 0.15f*((Hero) c).pointsInTalent(Talent.FARSIGHT);
 				viewDist *= EyeOfNewt.visionRangeMultiplier();
 			}
 			


### PR DESCRIPTION
Blazing no longer ticks damage against enemies on water tiles, this is mostly a Huntress nerf since blazing is still abusable, doesn't affect melee as much