### PR TITLE
Puzzle room adjustments

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
@@ -172,6 +172,10 @@ public class SentryRoom extends SpecialRoom {
 		entrance.set( Door.Type.REGULAR );
 	}
 
+	public boolean canPlaceWater(Point p){
+		return false;
+	}
+
 	private static Item prize(Level level ) {
 
 		Item prize;
@@ -252,7 +256,7 @@ public class SentryRoom extends SpecialRoom {
 
 			if (Dungeon.hero != null){
 				if (fieldOfView[Dungeon.hero.pos]
-						&& Dungeon.level.map[Dungeon.hero.pos] == Terrain.EMPTY_SP
+						&& (Dungeon.level.map[Dungeon.hero.pos] == Terrain.EMPTY_SP || Dungeon.level.map[Dungeon.hero.pos] == Terrain.WATER)
 						&& room.inside(Dungeon.level.cellToPoint(Dungeon.hero.pos))
 						&& !Dungeon.hero.belongings.lostInventory()){
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ToxicGasRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ToxicGasRoom.java
@@ -73,7 +73,7 @@ public class ToxicGasRoom extends SpecialRoom {
 		}
 
 		//skeleton with 2x gold, somewhat far from entry
-		//then 2 chests with regular gold (no mimics, chance for trinket catalyst)
+		//then 2 chests with regular gold (no mimics)
 		//we generate excess positions to ensure skull is far from entrance
 		ArrayList<Integer> goldPositions = new ArrayList<>();
 		for (int i = 0; i < 8; i++){
@@ -98,8 +98,7 @@ public class ToxicGasRoom extends SpecialRoom {
 		level.drop(mainGold, furthestPos).type = Heap.Type.SKELETON;
 
 		for (int i = 0; i < 2; i++){
-			Item item = level.findPrizeItem(TrinketCatalyst.class);
-			if (item == null) item = new Gold().random();
+			Item item = new Gold().random();
 			level.drop(item, goldPositions.remove(0)).type = Heap.Type.CHEST;
 		}
 


### PR DESCRIPTION
toxic gas rooms can no longer spawn with catalyst

red sentry fires on water tiles as well. removed water tiles from naturally generating on sentry room