### PR TITLE
Level feeling / darkness balancing

### DIFF
--- a/core/src/main/assets/messages/items/items.properties
+++ b/core/src/main/assets/messages/items/items.properties
@@ -1471,8 +1471,8 @@ items.trinkets.mimictooth.stats_desc=At its current level this trinket will make
 
 items.trinkets.mossyclump.name=mossy clump
 items.trinkets.mossyclump.desc=This clump of wet moss seems to hold onto its moisture no matter how hard you squeeze it. It seems to be magically tied to the dungeon itself, making grass and water more likely to appear.
-items.trinkets.mossyclump.typical_stats_desc=Typically this trinket will make _%d%%_ of unthemed floors become filled with either water or grass instead.\n\nThis trinket costs a moderately larger amount of energy to upgrade.
-items.trinkets.mossyclump.stats_desc=At its current level this trinket will make _%d%%_ of unthemed floors become filled with either water or grass instead.\n\nThis trinket costs a moderately larger amount of energy to upgrade.
+items.trinkets.mossyclump.typical_stats_desc=Typically this trinket will make _%d%%_ of unthemed floors (50%) become filled with either water or grass instead.\n\nThis trinket costs a moderately larger amount of energy to upgrade.
+items.trinkets.mossyclump.stats_desc=At its current level this trinket will make _%d%%_ of unthemed floors (50%) become filled with either water or grass instead.\n\nThis trinket costs a moderately larger amount of energy to upgrade.
 
 items.trinkets.parchmentscrap.name=parchment scrap
 items.trinkets.parchmentscrap.desc=This little scrap of parchment looks like it came from a scroll. It has retained some of its magic, and it seems to be influencing weapons and armor found in the dungeon.
@@ -1514,8 +1514,8 @@ items.trinkets.thirteenleafclover.stats_desc=At its current level this trinket w
 
 items.trinkets.trapmechanism.name=trap mechanism
 items.trinkets.trapmechanism.desc=The core mechanism of one of the dungeon's pitfall traps, carefully carved out of the floor so it can be carried. It seems to be magically tied to the dungeon itself, making hazardous terrain more common but also increasing your affinity towards it.
-items.trinkets.trapmechanism.typical_stats_desc=Typically this trinket will make _%1$d%%_ of unthemed floors become filled with either traps or chasms instead. Additionally, _%2$d%%_ of the dungeon's hidden traps will instead be visible.
-items.trinkets.trapmechanism.stats_desc=At its current level this trinket will make _%1$d%%_ of unthemed floors become filled with either traps or chasms instead. Additionally, _%2$d%%_ of the dungeon's hidden traps will instead be visible.
+items.trinkets.trapmechanism.typical_stats_desc=Typically this trinket will make _%1$d%%_ of unthemed floors (50%) become filled with either traps or chasms instead. Additionally, _%2$d%%_ of the dungeon's hidden traps will instead be visible.
+items.trinkets.trapmechanism.stats_desc=At its current level this trinket will make _%1$d%%_ of unthemed floors (50%) become filled with either traps or chasms instead. Additionally, _%2$d%%_ of the dungeon's hidden traps will instead be visible.
 
 items.trinkets.vialofblood.name=vial of blood
 items.trinkets.vialofblood.desc=This thin vial contains the blood of some denizen of the dungeon, it moves slowly as you rotate the vial. It seems to be magically enhancing stronger healing effects, but also delaying them.

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Dungeon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Dungeon.java
@@ -333,6 +333,7 @@ public class Dungeon {
 			SecretRoom.initForRun();
 
 			Generator.fullReset();
+			Level.Feeling.resetProbs();
 
 		Random.resetGenerators();
 		
@@ -754,6 +755,7 @@ public class Dungeon {
 			Statistics.storeInBundle( bundle );
 			Notes.storeInBundle( bundle );
 			Generator.storeInBundle( bundle );
+			Level.Feeling.storeInBundle( bundle );
 
 			int[] bundleArr = new int[generatedLevels.size()];
 			for (int i = 0; i < generatedLevels.size(); i++){
@@ -905,6 +907,7 @@ public class Dungeon {
 
 		Statistics.restoreFromBundle( bundle );
 		Generator.restoreFromBundle( bundle );
+		Level.Feeling.restoreFromBundle( bundle );
 
 
 		Polished.afterLoad.call();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/MagicalSight.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/MagicalSight.java
@@ -29,7 +29,7 @@ import com.watabou.noosa.Image;
 
 public class MagicalSight extends FlavourBuff {
 	
-	public static final float DURATION = 50f;
+	public static final float DURATION = 60f;
 	
 	public static final int DISTANCE = 12;
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Torch.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Torch.java
@@ -22,11 +22,13 @@
 package com.shatteredpixel.shatteredpixeldungeon.items;
 
 import com.shatteredpixel.shatteredpixeldungeon.Assets;
+import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Light;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.FlameParticle;
 import com.shatteredpixel.shatteredpixeldungeon.journal.Catalog;
+import com.shatteredpixel.shatteredpixeldungeon.levels.Level;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 import com.watabou.noosa.audio.Sample;
 import com.watabou.noosa.particles.Emitter;
@@ -63,15 +65,18 @@ public class Torch extends Item {
 			
 			hero.spend( TIME_TO_LIGHT );
 			hero.busy();
-			
 			hero.sprite.operate( hero.pos );
 			
 			detach( hero.belongings.backpack );
 			Catalog.countUse(getClass());
 			
-			Buff.affect(hero, Light.class, Light.DURATION);
-			Sample.INSTANCE.play(Assets.Sounds.BURNING);
+			float duration = Light.DURATION;
+			if(Dungeon.level.feeling == Level.Feeling.DARK) {
+				duration = Math.round(duration * 2/3f);
+			}
+			Buff.affect(hero, Light.class, duration);
 			
+			Sample.INSTANCE.play(Assets.Sounds.BURNING);
 			Emitter emitter = hero.sprite.centerEmitter();
 			emitter.start( FlameParticle.FACTORY, 0.2f, 3 );
 			
@@ -90,7 +95,7 @@ public class Torch extends Item {
 	
 	@Override
 	public int value() {
-		return 8 * quantity;
+		return 12 * quantity;
 	}
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/HallsLevel.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/HallsLevel.java
@@ -119,6 +119,9 @@ public class HallsLevel extends RegularLevel {
 	public void create() {
 		addItemToSpawn( new Torch() );
 		addItemToSpawn( new Torch() );
+		if (feeling == Feeling.LARGE){
+			addItemToSpawn( new Torch() );
+		}
 		super.create();
 	}
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
@@ -119,11 +119,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 
 public abstract class Level implements Bundlable {
 	
-	public static enum Feeling {
+	public enum Feeling {
 		NONE,
+		
 		CHASM,
 		WATER,
 		GRASS,
@@ -131,15 +133,77 @@ public abstract class Level implements Bundlable {
 		LARGE,
 		TRAPS,
 		SECRETS;
-
+		
+		public static final LinkedHashMap<Feeling, Float> defaultProbs = new LinkedHashMap<>();
+		public static final LinkedHashMap<Feeling, Float> probs;
+		static {
+			defaultProbs.put(CHASM, 	3f);
+			defaultProbs.put(WATER, 	3f);
+			defaultProbs.put(GRASS, 	3f);
+			defaultProbs.put(DARK, 		3f);
+			defaultProbs.put(LARGE, 	3f);
+			defaultProbs.put(TRAPS, 	3f);
+			defaultProbs.put(SECRETS,	3f);
+			
+			probs = (LinkedHashMap<Feeling, Float>) defaultProbs.clone();
+		}
+		
+		public static void resetProbs(){
+			for (Feeling feel : probs.keySet()) {
+				probs.put( feel, defaultProbs.get(feel) );
+			}
+		}
+		
+		public static Feeling random() {
+			Feeling feel = Random.chances(probs);
+			if (feel == null) {
+				resetProbs();
+				feel = Random.chances(probs);
+			}
+			
+			probs.put(feel, probs.get(feel)-1);
+			return feel;
+		}
+		
+		
+		private static final String FEELING_PROBS = "feeling_probs";
+		
+		public static void storeInBundle(Bundle bundle) {
+			Float[] feelProbs = probs.values().toArray(new Float[0]);
+			float[] storeProbs = new float[feelProbs.length];
+			
+			for (int i = 0; i < storeProbs.length; i++){
+				storeProbs[i] = feelProbs[i];
+			}
+			
+			bundle.put( FEELING, storeProbs);
+		}
+		
+		public static void restoreFromBundle(Bundle bundle) {
+			resetProbs();
+			
+			if (bundle.contains(FEELING_PROBS)) {
+				float[] feelProbs = bundle.getFloatArray(FEELING_PROBS);
+				
+				if (feelProbs.length == probs.size()) {
+					Feeling[] feelings = probs.keySet().toArray(new Feeling[0]);
+					
+					for (int i = 0; i < probs.size(); i++) {
+						probs.put(feelings[i], feelProbs[i]);
+					}
+				}
+			}
+		}
+		
+		
 		public String title(){
 			return Messages.get(this, name()+"_title");
 		}
-
 		public String desc() {
 			return Messages.get(this, name()+"_desc");
 		}
 	}
+	
 
 	protected int width;
 	protected int height;
@@ -255,42 +319,47 @@ public abstract class Level implements Bundlable {
 			}
 			
 			if (Dungeon.depth > 1) {
-				//50% chance of getting a level feeling
-				//~7.15% chance for each feeling
-				switch (Random.Int( 14 )) {
-					case 0:
-						feeling = Feeling.CHASM;
+				
+				if(Random.Int(2) == 0) {
+					feeling = Feeling.random();
+				}
+				else {
+					//if-else statements are fine here as only one chance can be above 0 at a time
+					if (Random.Float() < MossyClump.overrideNormalLevelChance()){
+						feeling = MossyClump.getNextFeeling();
+					} else if (Random.Float() < TrapMechanism.overrideNormalLevelChance()) {
+						feeling = TrapMechanism.getNextFeeling();
+					} else {
+						feeling = Feeling.NONE;
+					}
+				}
+				
+				switch (feeling) {
+					case CHASM:
+						Notes.add(Notes.Landmark.CHASM_FLOOR);
 						break;
-					case 1:
-						feeling = Feeling.WATER;
+					case WATER:
+						Notes.add(Notes.Landmark.WATER_FLOOR);
 						break;
-					case 2:
-						feeling = Feeling.GRASS;
+					case GRASS:
+						Notes.add(Notes.Landmark.GRASS_FLOOR);
 						break;
-					case 3:
-						feeling = Feeling.DARK;
-						viewDistance = Math.round(5*viewDistance/8f);
+					case DARK:
+						Notes.add(Notes.Landmark.DARK_FLOOR);
+						viewDistance = Math.max(2, Math.round(viewDistance * 2/3f));
 						break;
-					case 4:
-						feeling = Feeling.LARGE;
+					case LARGE:
+						Notes.add(Notes.Landmark.LARGE_FLOOR);
 						addItemToSpawn(Generator.random(Generator.Category.FOOD));
 						break;
-					case 5:
-						feeling = Feeling.TRAPS;
+					case TRAPS:
+						Notes.add(Notes.Landmark.TRAPS_FLOOR);
 						break;
-					case 6:
-						feeling = Feeling.SECRETS;
+					case SECRETS:
+						Notes.add(Notes.Landmark.SECRETS_FLOOR);
 						break;
-					default:
-						//if-else statements are fine here as only one chance can be above 0 at a time
-						if (Random.Float() < MossyClump.overrideNormalLevelChance()){
-							feeling = MossyClump.getNextFeeling();
-						} else if (Random.Float() < TrapMechanism.overrideNormalLevelChance()) {
-							feeling = TrapMechanism.getNextFeeling();
-						} else {
-							feeling = Feeling.NONE;
-						}
 				}
+				
 			}
 		}
 		
@@ -442,7 +511,7 @@ public abstract class Level implements Bundlable {
 
 		feeling = bundle.getEnum( FEELING, Feeling.class );
 		if (feeling == Feeling.DARK) {
-			viewDistance = Math.round(5 * viewDistance / 8f);
+			viewDistance = Math.max(2, Math.round(viewDistance * 2/3f));
 		}
 
 		if (bundle.contains( "mobs_to_spawn" )) {
@@ -735,10 +804,13 @@ public abstract class Level implements Bundlable {
 				//respawn time is 5/5/10/15/20/25/25, etc.
 				cooldown = Math.round(GameMath.gate( TIME_TO_RESPAWN/10f, Dungeon.level.mobCount() * (TIME_TO_RESPAWN / 10f), TIME_TO_RESPAWN / 2f));
 			}
-		} else if (Dungeon.level.feeling == Feeling.DARK){
-			cooldown = 2*TIME_TO_RESPAWN/3f;
-		} else {
+		}
+		else {
 			cooldown = TIME_TO_RESPAWN;
+		}
+		
+		if (Dungeon.level.feeling == Feeling.DARK){
+			cooldown *= 2/3f;
 		}
 
 		cooldown /= DimensionalSundial.spawnMultiplierAtCurrentTime();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/RegularLevel.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/RegularLevel.java
@@ -473,7 +473,7 @@ public abstract class RegularLevel extends Level {
 		//we can use a random long for these as they will be the same longs every time
 
 		Random.pushGenerator( Random.Long() );
-			if (Dungeon.isChallenged(Challenges.DARKNESS)){
+			if (Dungeon.isChallenged(Challenges.DARKNESS) && !(this instanceof HallsLevel)){
 				int cell = randomDropCell();
 				if (map[cell] == Terrain.HIGH_GRASS || map[cell] == Terrain.FURROWED_GRASS) {
 					map[cell] = Terrain.GRASS;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ShopRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ShopRoom.java
@@ -248,7 +248,6 @@ public class ShopRoom extends SpecialRoom {
 			itemsToSpawn.add( new PlateArmor().identify(false) );
 			itemsToSpawn.add( new Torch() );
 			itemsToSpawn.add( new Torch() );
-			itemsToSpawn.add( new Torch() );
 			break;
 		}
 		w.enchant(null);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/GameScene.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/GameScene.java
@@ -634,31 +634,24 @@ public class GameScene extends PixelScene {
 			switch (Dungeon.level.feeling) {
 				case CHASM:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.CHASM_FLOOR);
 					break;
 				case WATER:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.WATER_FLOOR);
 					break;
 				case GRASS:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.GRASS_FLOOR);
 					break;
 				case DARK:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.DARK_FLOOR);
 					break;
 				case LARGE:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.LARGE_FLOOR);
 					break;
 				case TRAPS:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.TRAPS_FLOOR);
 					break;
 				case SECRETS:
 					GLog.w(Dungeon.level.feeling.desc());
-					Notes.add(Notes.Landmark.SECRETS_FLOOR);
 					break;
 			}
 


### PR DESCRIPTION
Implemented level feeling probability deck
Landmark bugfix

Dark feeling mini-rework:
Vision mult 5/8 -> 2/3 (basically the same with rounding) No longer drops vision below 2, but...
Reduces torch duration (* 2/3)

halls no extra torches on darkness chall
200->300g imp shop cost
-1 torch on shop

magical sight duration buff 50->60

mossy/trap mech trinket desc improvement